### PR TITLE
Don't require HOME_PATH to be set or to be an absolute directory

### DIFF
--- a/game.cfg
+++ b/game.cfg
@@ -9,13 +9,13 @@
 # 'docs/SDLKeycodeLookup.htm' which was
 # distributed with the game.
 
-HOME_PATH <full system path without trailing slash>
+# HOME_PATH <full system path without trailing slash>
 
 # Arrow key keycodes (WARNING: these and other K<number> codes you use may be buggy):
-# left: K1073741904
-# right: K1073741903
-# up: K1073741906
-# down: K1073741905
+# P1LEFT      K1073741904
+# P1RIGHT     K1073741903
+# P1UP        K1073741906
+# P1DOWN      K1073741905
 
 P1CONTROLS
 


### PR DESCRIPTION
Game now works out of the box after compiling without setting HOME_PATH.
We should revisit the directory structure later to properly split static assets and per-user writable data.
