### PR TITLE
Makefile fixes for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,14 @@ OBJ_PATH = obj
 # Do it Do it
 
 INCLUDES = 
-COMPILER_FLAGS = -Wall -Werror -Wno-comment -Wno-misleading-indentation -Wno-unused-variable -Wno-unused-parameter -g
+COMPILER_FLAGS = -Wall -Werror -Wno-comment -Wno-unused-variable -Wno-unused-parameter -g
 LINK_FLAGS = -lSDL2 -lSDL2_image -lSDL2_mixer -lm
 
 CFLAGS = $(COMPILER_FLAGS)
 ifeq ($(OS), Windows_NT)
 	CFLAGS += -lmingw32 -lSDL2main
 endif
-CFLAGS += $(LINK_FLAGS)
+#CFLAGS += $(LINK_FLAGS)
 
 SRC = $(wildcard $(SRC_PATH)/*.c)
 # SRC = $(shell find $(SRC_PATH) -name '*.c' -printf '%T@\t%p\n' | sort -k 1nr | cut -f2-)
@@ -31,7 +31,7 @@ all: dirs game
 	@ln -s $(BIN_PATH)/$(BIN_NAME) $(BIN_NAME)
 
 game : $(OBJ)
-	$(CC) $(OBJ) $(CFLAGS) -o $(BIN_PATH)/$(BIN_NAME)
+	$(CC) $(OBJ) $(CFLAGS) $(LINK_FLAGS) -o $(BIN_PATH)/$(BIN_NAME)
 
 -include $(DEPS)
 


### PR DESCRIPTION
Removed clang-incompatible -Wno-misleading-indentation flag, moved link_flags to link step